### PR TITLE
CODE RUB: Simplify Http Exception Tests

### DIFF
--- a/DMX.Gatekeeper.Api.Tests.Acceptance/DMX.Gatekeeper.Api.Tests.Acceptance.csproj
+++ b/DMX.Gatekeeper.Api.Tests.Acceptance/DMX.Gatekeeper.Api.Tests.Acceptance.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	<TargetFramework>net7.0</TargetFramework>
@@ -11,7 +11,7 @@
     <PackageReference Include="DeepCloner" Version="0.10.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0-preview.5.22303.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0-preview-20220612-01" />
-    <PackageReference Include="RESTFulSense" Version="2.7.0" />
+    <PackageReference Include="RESTFulSense" Version="2.8.0" />
     <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.8" />
     <PackageReference Include="WireMock.Net" Version="1.5.0" />
     <PackageReference Include="xunit" Version="2.4.2-pre.12" />

--- a/DMX.Gatekeeper.Api.Tests.Unit/Services/Foundations/Labs/LabServiceTests.Exceptions.Add.cs
+++ b/DMX.Gatekeeper.Api.Tests.Unit/Services/Foundations/Labs/LabServiceTests.Exceptions.Add.cs
@@ -66,11 +66,9 @@ namespace DMX.Gatekeeper.Api.Tests.Unit.Services.Foundations.Labs
         {
             // given
             Lab randomLab = CreateRandomLab();
-            string randomMessage = GetRandomString();
-            var httpMessage = new HttpResponseMessage();
 
             var httpResponseException =
-                new HttpResponseException(httpMessage, randomMessage);
+                new HttpResponseException();
 
             var failedLabDependencyException =
                 new FailedLabDependencyException(httpResponseException);
@@ -209,24 +207,12 @@ namespace DMX.Gatekeeper.Api.Tests.Unit.Services.Foundations.Labs
         {
             // given
             Lab randomLab = CreateRandomLab();
-            string randomString = GetRandomString();
-
-            Dictionary<string, List<string>> randomDictionary =
-                CreateRandomDictionary();
-
-            var httpResponseMessage = new HttpResponseMessage();
-
+            
             var httpResponseConflictException =
-                new HttpResponseConflictException(
-                    httpResponseMessage,
-                    randomString);
-
-            httpResponseConflictException.AddData(randomDictionary);
+                new HttpResponseConflictException();
 
             var alreadyExistsLabException =
-                new AlreadyExistsLabException(
-                    httpResponseConflictException,
-                    randomDictionary);
+                new AlreadyExistsLabException(httpResponseConflictException);
 
             var expectedLabDependencyValidationException =
                 new LabDependencyValidationException(alreadyExistsLabException);

--- a/DMX.Gatekeeper.Api.Tests.Unit/Services/Foundations/Labs/LabServiceTests.Exceptions.RetrieveAll.cs
+++ b/DMX.Gatekeeper.Api.Tests.Unit/Services/Foundations/Labs/LabServiceTests.Exceptions.RetrieveAll.cs
@@ -63,14 +63,8 @@ namespace DMX.Gatekeeper.Api.Tests.Unit.Services.Foundations.Labs
         public async Task ShouldThrowDependencyExceptionOnRetrieveIfErrorOccursAndLogItAsync()
         {
             // given
-            string someMessage = GetRandomString();
-
-            var someResponseMessage = new HttpResponseMessage();
-
             var httpResponseException =
-                new HttpResponseException(
-                    someResponseMessage,
-                    someMessage);
+                new HttpResponseException();
 
             var failedLabDependencyException =
                 new FailedLabDependencyException(httpResponseException);

--- a/DMX.Gatekeeper.Api.Tests.Unit/Services/Foundations/Labs/LabServiceTests.cs
+++ b/DMX.Gatekeeper.Api.Tests.Unit/Services/Foundations/Labs/LabServiceTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Net.Http;
 using DMX.Gatekeeper.Api.Brokers.DmxApis;
 using DMX.Gatekeeper.Api.Brokers.Loggings;
 using DMX.Gatekeeper.Api.Models.Labs;
@@ -37,14 +36,11 @@ namespace DMX.Gatekeeper.Api.Tests.Unit.Services.Foundations.Labs
 
         public static TheoryData CriticalDependencyException()
         {
-            string someMessage = GetRandomString();
-            var someResponseMessage = new HttpResponseMessage();
-
             return new TheoryData<Xeption>()
             {
-                new HttpResponseUrlNotFoundException(someResponseMessage, someMessage),
-                new HttpResponseUnauthorizedException(someResponseMessage, someMessage),
-                new HttpResponseForbiddenException(someResponseMessage, someMessage),
+                new HttpResponseUrlNotFoundException(),
+                new HttpResponseUnauthorizedException(),
+                new HttpResponseForbiddenException(),
             };
         }
 

--- a/DMX.Gatekeeper.Api/DMX.Gatekeeper.Api.csproj
+++ b/DMX.Gatekeeper.Api/DMX.Gatekeeper.Api.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.4" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.16.0" />
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.16.0" />
-    <PackageReference Include="RESTFulSense" Version="2.7.0" />
+    <PackageReference Include="RESTFulSense" Version="2.8.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     <PackageReference Include="Xeption" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
This change simplifies our tests for `HttpResponseException` and it's derivatives. It leverages new simplified models from RESTFulSense `v2.8.0`.

Here's how our tests look before using the new version:

```csharp
        [Fact]
        public async Task ShouldThrowDependencyExceptionOnAddIfErrorOccursAndLogItAsync()
        {
            // given
            Lab randomLab = CreateRandomLab();
            string randomMessage = GetRandomString();
            var httpMessage = new HttpResponseMessage();

            var httpResponseException =
                new HttpResponseException(httpMessage, randomMessage);

            var failedLabDependencyException =
                new FailedLabDependencyException(httpResponseException);

            var expectedLabDependencyException =
                new LabDependencyException(failedLabDependencyException);
            ...
            ...
         }
```

Here's our tests after using the new version:

```csharp
        [Fact]
        public async Task ShouldThrowDependencyExceptionOnAddIfErrorOccursAndLogItAsync()
        {
            // given
            Lab randomLab = CreateRandomLab();

            var httpResponseException =
                new HttpResponseException();

            var failedLabDependencyException =
                new FailedLabDependencyException(httpResponseException);

            var expectedLabDependencyException =
                new LabDependencyException(failedLabDependencyException);
            ...
            ...
         }
```




